### PR TITLE
feat(analysis): add sequence of returns risk analysis

### DIFF
--- a/index.html
+++ b/index.html
@@ -576,7 +576,7 @@
                                 <span class="tooltip-text">O número de vezes que a simulação será executada. Mais simulações dão um resultado estatisticamente mais robusto, mas demoram mais tempo. 1000 a 5000 é um bom intervalo.</span>
                             </span>
                         </label>
-                        <input type="number" id="mcNumSimulacoes" class="form-control" value="1000" min="100" max="10000" step="100">
+                        <input type="number" id="mcNumSimulacoes" class="form-control" value="2500" min="100" max="10000" step="100">
                     </div>
                 </div>
                 <div class="resultados-grid">
@@ -626,6 +626,32 @@
                             <!-- Os resultados da análise serão inseridos aqui -->
                         </tbody>
                     </table>
+                </div>
+            </div>
+        </section>
+<section id="sequenceOfReturnsRisk" class="card section hidden">
+            <div class="card__header">
+                <h2>Análise de Risco de Sequência de Retornos
+                    <span class="tooltip-container">
+                        <span class="tooltip-icon">i</span>
+                        <span class="tooltip-text">Esta análise simula o impacto de uma crise de mercado no início da sua reforma para testar a robustez do seu plano.</span>
+                    </span>
+                </h2>
+            </div>
+            <div class="card__body">
+                <div class="form-row" style="margin-bottom: 24px;">
+                    <div class="form-group">
+                        <label for="srrDuration" class="form-label">Duração do Cenário (Anos)</label>
+                        <input type="number" id="srrDuration" class="form-control" value="5" min="1" max="20">
+                    </div>
+                    <div class="form-group">
+                        <label for="srrReturn" class="form-label">Retorno Anual no Cenário (%)</label>
+                        <input type="number" id="srrReturn" class="form-control" value="-10" max="100">
+                    </div>
+                </div>
+                <button type="button" id="btnSimularSRR" class="btn btn--primary">Simular Risco de Sequência</button>
+                <div class="chart-container" style="height: 400px; width: 100%; margin-top: 24px;">
+                    <canvas id="chartSequenceOfReturns"></canvas>
                 </div>
             </div>
         </section>

--- a/src/app.js
+++ b/src/app.js
@@ -31,8 +31,8 @@ import {
     hideLoader
 } from './ui.js';
 
-import { simularEvolucaoPatrimonial, simularMonteCarlo } from './calculator.js';
-import { atualizarGraficos, criarGraficoMonteCarloDistribution } from './charts.js';
+import { simularEvolucaoPatrimonial, simularMonteCarlo, simularSequenceOfReturnsRisk } from './calculator.js';
+import { atualizarGraficos, criarGraficoMonteCarloDistribution, criarGraficoSequenceOfReturns } from './charts.js';
 import { gerarPDF } from './pdf.js';
 
 // --- Funções de Lógica de Negócio (Handlers) ---
@@ -245,6 +245,26 @@ function importarDados() {
     input.click();
 }
 
+async function calcularSRR() {
+    showLoader();
+    await new Promise(resolve => setTimeout(resolve, 50)); // Allow UI to update
+
+    try {
+        const srrDuration = parseInt(document.getElementById('srrDuration').value, 10);
+        const srrReturn = parseFloat(document.getElementById('srrReturn').value);
+
+        const originalResults = simularEvolucaoPatrimonial();
+        const stressResults = simularSequenceOfReturnsRisk(srrDuration, srrReturn);
+
+        const srrSection = document.getElementById('sequenceOfReturnsRisk');
+        srrSection.classList.remove('hidden');
+
+        criarGraficoSequenceOfReturns(originalResults.historicoPatrimonialAnual, stressResults.historicoPatrimonialAnual);
+    } finally {
+        hideLoader();
+    }
+}
+
 // --- Configuração de Event Listeners ---
 
 function handleTableActions(event) {
@@ -441,6 +461,8 @@ function configurarEventListeners() {
            calcularResultados();
        });
    });
+
+    document.getElementById('btnSimularSRR').addEventListener('click', calcularSRR);
 }
 
 // --- Inicialização da Aplicação ---

--- a/src/charts.js
+++ b/src/charts.js
@@ -385,4 +385,67 @@ function criarGraficoMonteCarloDistribution(resultados) {
 }
 
 
-export { atualizarGraficos, criarGraficoMonteCarloDistribution };
+let chartSequenceOfReturns = null;
+
+function criarGraficoSequenceOfReturns(originalData, stressData) {
+    const ctx = document.getElementById('chartSequenceOfReturns').getContext('2d');
+
+    if (chartSequenceOfReturns) {
+        chartSequenceOfReturns.destroy();
+    }
+
+    const labels = originalData.map(d => d.ano);
+    const originalValues = originalData.map(d => d.valorNominal);
+    const stressValues = stressData.map(d => d.valorNominal);
+
+    chartSequenceOfReturns = new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels: labels,
+            datasets: [{
+                label: 'Projeção Original',
+                data: originalValues,
+                borderColor: '#1FB8CD',
+                backgroundColor: 'rgba(31, 184, 205, 0.1)',
+                tension: 0.1,
+                fill: true
+            }, {
+                label: 'Projeção com Stress Test',
+                data: stressValues,
+                borderColor: '#B4413C',
+                backgroundColor: 'rgba(180, 65, 60, 0.1)',
+                tension: 0.1,
+                fill: true
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: {
+                        callback: function(value) {
+                            return '€' + value.toLocaleString();
+                        }
+                    }
+                }
+            },
+            plugins: {
+                legend: {
+                    position: 'top'
+                },
+                tooltip: {
+                    mode: 'index',
+                    intersect: false,
+                    callbacks: {
+                        label: function(context) {
+                            return `${context.dataset.label}: €${Math.round(context.raw).toLocaleString()}`;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+export { atualizarGraficos, criarGraficoMonteCarloDistribution, criarGraficoSequenceOfReturns };

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -1,35 +1,59 @@
 import { dadosApp } from './state.js';
-import { simularEvolucaoPatrimonial } from './calculator.js';
+import { simularEvolucaoPatrimonial, simularMonteCarlo } from './calculator.js';
 import { mostrarMensagem } from './ui.js';
 
 function gerarPDF() {
     try {
         mostrarMensagem('Gerando PDF...', 'info');
         const resultados = simularEvolucaoPatrimonial(); // Usar dados frescos
+        const mcResults = simularMonteCarlo(1000); // Usar 1000 simulações para o PDF
+
         const { jsPDF } = window.jspdf;
         if (!jsPDF) {
             throw new Error('Biblioteca jsPDF não está carregada.');
         }
         const doc = new jsPDF();
 
-        // --- Configurações e Cabeçalho ---
-        doc.setProperties({
-            title: 'Relatório FIRE',
-            subject: 'Análise de Independência Financeira',
-            author: 'Calculadora FIRE',
-        });
-        doc.setFontSize(20);
-        doc.setTextColor(33, 128, 141);
-        doc.text('Relatório de Análise FIRE', 20, 25);
-        doc.setFontSize(10);
-        doc.setTextColor(98, 108, 113);
-        doc.text(`Gerado em: ${new Date().toLocaleDateString('pt-PT')}`, 20, 35);
-        doc.setDrawColor(33, 128, 141);
-        doc.line(20, 40, 190, 40);
+        let yPos = 0;
 
-        let yPos = 50;
+        // --- Função auxiliar para adicionar o cabeçalho ---
+        const addHeader = () => {
+            doc.setFontSize(20);
+            doc.setTextColor(33, 128, 141);
+            doc.text('Relatório de Análise FIRE', 20, 25);
+            doc.setFontSize(10);
+            doc.setTextColor(98, 108, 113);
+            doc.text(`Gerado em: ${new Date().toLocaleDateString('pt-PT')}`, 20, 35);
+            doc.setDrawColor(33, 128, 141);
+            doc.line(20, 40, 190, 40);
+            yPos = 50;
+        };
+
+        // --- Função auxiliar para adicionar o rodapé ---
+        const addFooter = () => {
+            const pageCount = doc.internal.getNumberOfPages();
+            for (let i = 1; i <= pageCount; i++) {
+                doc.setPage(i);
+                doc.setFontSize(8);
+                doc.setTextColor(128, 128, 128);
+                doc.text(`Página ${i} de ${pageCount}`, 175, 285);
+                doc.text('Calculadora FIRE © 2025', 20, 285);
+            }
+        };
+        
+        // --- Função auxiliar para adicionar uma nova página se necessário ---
+        const checkPageBreak = (neededHeight) => {
+            if (yPos + neededHeight > 280) {
+                doc.addPage();
+                addHeader();
+            }
+        };
+
+        // --- Início do Documento ---
+        addHeader();
 
         // --- Dados Base ---
+        checkPageBreak(40);
         doc.setFontSize(14);
         doc.setTextColor(19, 52, 59);
         doc.text('Dados de Base', 20, yPos);
@@ -45,12 +69,13 @@ function gerarPDF() {
         yPos += 7;
         doc.text(`Taxa de Retirada Segura: ${dadosBasicos.taxaRetirada}%`, 20, yPos);
         doc.text(`Inflação Anual Esperada: ${dadosBasicos.inflacaoAnual}%`, 100, yPos);
+        yPos += 15;
 
         // --- Resultados da Simulação ---
-        yPos += 20;
+        checkPageBreak(40);
         doc.setFontSize(14);
         doc.setTextColor(19, 52, 59);
-        doc.text('Resultados da Simulação', 20, yPos);
+        doc.text('Resultados da Simulação Determinística', 20, yPos);
         yPos += 10;
         doc.setFontSize(10);
         doc.setTextColor(0, 0, 0);
@@ -60,10 +85,10 @@ function gerarPDF() {
         yPos += 7;
         doc.text(`Taxa de Retorno Nominal Ponderada: ${resultados.taxaRetornoNominal.toFixed(2)}%`, 20, yPos);
         doc.text(`Taxa de Retorno Real (descontada a inflação): ${resultados.taxaRetornoReal.toFixed(2)}%`, 100, yPos);
+        yPos += 15;
 
         // --- Gráfico de Evolução Patrimonial ---
-        yPos += 15;
-        if (yPos > 240) { doc.addPage(); yPos = 20; }
+        checkPageBreak(100);
         doc.setFontSize(14);
         doc.setTextColor(19, 52, 59);
         doc.text('Gráfico de Evolução Patrimonial', 20, yPos);
@@ -75,7 +100,7 @@ function gerarPDF() {
 
         // --- Tabelas de Dados ---
         const addTable = (title, headers, data) => {
-            if (yPos > 220) { doc.addPage(); yPos = 20; }
+            checkPageBreak(40 + data.length * 10); // Estimativa de altura
             doc.setFontSize(14);
             doc.setTextColor(19, 52, 59);
             doc.text(title, 20, yPos);
@@ -100,17 +125,56 @@ function gerarPDF() {
             dadosApp.despesasVariaveis.map(d => [d.descricao, `€${d.valorMensal}`, d.anoInicio, d.anoFim])
         );
 
-        // --- Rodapé ---
-        const pageCount = doc.internal.getNumberOfPages();
-        for (let i = 1; i <= pageCount; i++) {
-            doc.setPage(i);
-            doc.setFontSize(8);
-            doc.setTextColor(128, 128, 128);
-            doc.text(`Página ${i} de ${pageCount}`, 175, 285);
-            doc.text('Calculadora FIRE © 2025', 20, 285);
-        }
+        // --- Gráfico de Alocação de Ativos ---
+        checkPageBreak(100);
+        doc.setFontSize(14);
+        doc.setTextColor(19, 52, 59);
+        doc.text('Gráfico de Alocação de Ativos', 20, yPos);
+        yPos += 10;
+        const assetCanvas = document.getElementById('chartAssetAllocation');
+        const assetImgData = assetCanvas.toDataURL('image/png');
+        doc.addImage(assetImgData, 'PNG', 20, yPos, 80, 80);
+        yPos += 90;
 
-        // --- Salvar PDF ---
+        // --- Gráfico de Evolução das Despesas ---
+        checkPageBreak(100);
+        doc.setFontSize(14);
+        doc.setTextColor(19, 52, 59);
+        doc.text('Gráfico de Evolução das Despesas', 20, yPos);
+        yPos += 10;
+        const despesasCanvas = document.getElementById('chartDespesasVariaveis');
+        const despesasImgData = despesasCanvas.toDataURL('image/png');
+        doc.addImage(despesasImgData, 'PNG', 20, yPos, 170, 80);
+        yPos += 90;
+
+        // --- Resultados da Simulação de Monte Carlo ---
+        checkPageBreak(40);
+        doc.setFontSize(14);
+        doc.setTextColor(19, 52, 59);
+        doc.text('Resultados da Simulação de Monte Carlo', 20, yPos);
+        yPos += 10;
+        doc.setFontSize(10);
+        doc.setTextColor(0, 0, 0);
+        doc.text(`Património Mediano (P50): €${Math.round(mcResults.p50).toLocaleString()}`, 20, yPos);
+        doc.text(`Taxa de Sucesso: ${mcResults.taxaDeSucesso.toFixed(1)}%`, 100, yPos);
+        yPos += 7;
+        doc.text(`Património Pessimista (P10): €${Math.round(mcResults.p10).toLocaleString()}`, 20, yPos);
+        doc.text(`Património Otimista (P90): €${Math.round(mcResults.p90).toLocaleString()}`, 100, yPos);
+        yPos += 15;
+
+        // --- Gráfico de Distribuição de Monte Carlo ---
+        checkPageBreak(100);
+        doc.setFontSize(14);
+        doc.setTextColor(19, 52, 59);
+        doc.text('Gráfico de Distribuição de Monte Carlo', 20, yPos);
+        yPos += 10;
+        const mcCanvas = document.getElementById('chartMonteCarloDistribution');
+        const mcImgData = mcCanvas.toDataURL('image/png');
+        doc.addImage(mcImgData, 'PNG', 20, yPos, 170, 80);
+        yPos += 90;
+
+        // --- Finalizar e Salvar ---
+        addFooter();
         const nomeArquivo = `Relatorio_FIRE_${new Date().toISOString().slice(0, 10)}.pdf`;
         doc.save(nomeArquivo);
         mostrarMensagem('PDF gerado e baixado com sucesso!', 'success');


### PR DESCRIPTION
Implements a new section for Sequence of Returns Risk (SRR) analysis, allowing users to simulate market downturns at the start of retirement. Adds input fields for scenario duration and annual return, and displays results with a dedicated chart.

Enhances PDF report generation by including Monte Carlo simulation results, Asset Allocation, and Expense Evolution charts. Improves PDF pagination and header/footer management for a more robust report. Updates default Monte Carlo simulation count to 2500 for consistency.